### PR TITLE
Allow onMessage to be set and processed

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,11 +81,11 @@ export default class MyWebView extends Component {
         ref={(ref) => { this.webview = ref; }}
         injectedJavaScript={Platform.OS === 'ios' ? iosScript : androidScript}
         scrollEnabled={this.props.scrollEnabled || false}
-        onMessage={this._onMessage}
         javaScriptEnabled={true}
         automaticallyAdjustContentInsets={true}
         {...this.props}
-        style={[{width: _w}, this.props.style, {height: _h}]}
+	onMessage={this._onMessage}
+	style={[{ width: _w }, this.props.style, { height: _h }]}
       />
     )
   }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ import {
   WebView,
   Platform,
 } from 'react-native';
+import PropTypes from "prop-types";
 
 const injectedScript = function() {
   function waitForBridge() {
@@ -57,9 +58,11 @@ export default class MyWebView extends Component {
   }
 
   _onMessage(e) {
+    const { onMessage } = this.props;
     this.setState({
       webViewHeight: parseInt(e.nativeEvent.data)
     });
+    onMessage(e);
   }
 
   stopLoading() {

--- a/index.js
+++ b/index.js
@@ -38,9 +38,14 @@ export default class MyWebView extends Component {
     webViewHeight: Number
   };
 
+  static propTypes = {
+    onMessage: PropTypes.func
+  };
+
   static defaultProps = {
-      autoHeight: true,
-  }
+    autoHeight: true,
+    onMessage: () => {}
+  };
 
   constructor (props: Object) {
     super(props);


### PR DESCRIPTION
(Similar issue is in https://github.com/scazzy/react-native-webview-autoheight/pull/16 , but their fix doesn't work).

Currently, if you set onMessage, the spread of this.props on the webview overwrites the call to _onMessage , rendering the component useless.

To fix I have:
* reorder the properties on the webview, to ensure onMessage is not overwritten
* ensure there is a default onMessage function (no-op)
* Added a call to the passed onMessage once _onMessage has dealt with the height.
