### PR TITLE
Replace WebView from core with react-native-webview

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,17 +20,9 @@ import {
 import { WebView } from 'react-native-webview';
 
 const injectedScript = function() {
-  function waitForBridge() {
-    if (window.postMessage.length !== 1){
-      setTimeout(waitForBridge, 200);
-    }
-    else {
-      postMessage(
-        Math.max(document.documentElement.clientHeight, document.documentElement.scrollHeight, document.body.clientHeight, document.body.scrollHeight)
-      )
-    }
-  }
-  waitForBridge();
+  window.ReactNativeWebView.postMessage(
+    Math.max(document.documentElement.clientHeight, document.documentElement.scrollHeight, document.body.clientHeight, document.body.scrollHeight)
+  )
 };
 
 export default class MyWebView extends Component {

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ import React, { Component } from 'react';
 import {
   View,
   Dimensions,
-  WebView,
   Platform,
 } from 'react-native';
+import { WebView } from 'react-native-webview';
 
 const injectedScript = function() {
   function waitForBridge() {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/scazzy/react-native-webview-autoheight/issues"
   },
-  "homepage": "https://github.com/scazzy/react-native-webview-autoheight#readme"
+  "homepage": "https://github.com/scazzy/react-native-webview-autoheight#readme",
+  "dependencies": {
+    "react-native-webview": "^5.7.1"
+  }
 }


### PR DESCRIPTION
Due to the fact that WebView is about to leave React Native Core and was already move to a separate repository (see: https://github.com/react-native-community/react-native-webview), I have updated the import and added dependency.

More on the 'lean core' initiative:
https://github.com/facebook/react-native/issues/23313